### PR TITLE
Set timestamp on priors on constant parameters

### DIFF
--- a/roamfree/ROAMestimation/include/ROAMestimation/ConstantParameter.h
+++ b/roamfree/ROAMestimation/include/ROAMestimation/ConstantParameter.h
@@ -69,6 +69,15 @@ class ConstantParameter: public ParameterVerticesManager {
 
     virtual void prepareForPoseRemoval(double mintstamp, double maxtstamp) {
     }
+
+    inline double getNextPriorIndex() {
+        return _nbPriors++;
+    }
+
+  protected:
+    // Number of existing priors on this parameter, this is used as timestamp to disambiguate
+    // different priors and avoid reading uninitialized memory
+    double _nbPriors = 0.0;
 };
 
 } /* namespace ROAMestimation */

--- a/roamfree/ROAMestimation/include/ROAMestimation/FactorGraphFilterImpl.h
+++ b/roamfree/ROAMestimation/include/ROAMestimation/FactorGraphFilterImpl.h
@@ -128,12 +128,12 @@ class FactorGraphFilter_Impl: public FactorGraphFilter {
         const std::string &name, ParameterWrapperVector_Ptr toblend);
 
     ParameterWrapper_Ptr getParameterByName(const std::string &name);
-    
+
     /* --------------------------- POSES AND EDGES LEVEL METHODS ---------------------- */
 
     PoseVertexWrapper_Ptr addPose(double t);
 
-    PoseVertexWrapper_Ptr addInterpolatingPose(double t, ParameterWrapper_Ptr delayParam, 
+    PoseVertexWrapper_Ptr addInterpolatingPose(double t, ParameterWrapper_Ptr delayParam,
         const Eigen::MatrixXd &pseudoObsCov);
 
     MeasurementEdgeWrapper_Ptr addMeasurement(const std::string& sensorName,
@@ -193,7 +193,7 @@ class FactorGraphFilter_Impl: public FactorGraphFilter {
     bool estimate(int nIterations);
 
     bool estimate(PoseVertexWrapperVector poses, int nIterations);
-    
+
     void computeCrossCovariances();
     /* --------------------------- OTHER STUFF ---------------------------------------- */
 
@@ -226,7 +226,7 @@ class FactorGraphFilter_Impl: public FactorGraphFilter {
     ROAMlog::GraphLogger *_logger; //!< the object which handles low level logging
     std::string _logFolder;
 
-    SpatialIndex *_spatialIndex; //!< the object which maintains spatial informations about poses.    
+    SpatialIndex *_spatialIndex; //!< the object which maintains spatial informations about poses.
 
     /* --------------------------- STUFF FOR SENSORS ------------------------------- */
 
@@ -252,7 +252,7 @@ class FactorGraphFilter_Impl: public FactorGraphFilter {
 
     //! collection for the parameter descriptors
     std::map<std::string, boost::shared_ptr<ParameterVerticesManager> > _params;
-    
+
 
     /* --------------------------- STUFF FOR POSES AND MEASUREMENTS ------------------- */
 

--- a/roamfree/ROAMestimation/src/FactorGraphFilterImpl.cpp
+++ b/roamfree/ROAMestimation/src/FactorGraphFilterImpl.cpp
@@ -552,6 +552,7 @@ MeasurementEdgeWrapper_Ptr FactorGraphFilter_Impl::addPriorOnConstantParameter(
   priorif->setMeasurement(x0);
   priorif->setNoiseCov(cov);
   priorif->setCategory(name+"_prior");
+  priorif->setTimestamp(cnst_par->getNextPriorIndex());
 
   _optimizer->addEdge(edge);
 


### PR DESCRIPTION
The timestamp of the prior edge was not initialized, resulting in:
- Unrepeatable output since uninitialized memory is written as timestamp in output files.
- Occasional crashes when using multiple prior edges on the same parameter, since the timestamp can be NaN, which triggers undefined behavior (materialized as floating point exception) when used as keys in a map. World coordinates of GCPs in ROAMvision have 2 priors and thus occasionally trigger the problem

There is no significant timestamp value for a prior on a constant parameter, so fixing this parameter as 0.0 seems reasonnable. This patch increments the used value by 1.0 for every additionnal prior added to the same parameter since the ROAMlog code expects the (Category, timestamp) tuple to uniquely identify an edge (using 0.0 for all priors would result in only one being logged).